### PR TITLE
Allow attachments to be filtered more easily by using array keys.

### DIFF
--- a/templates/json-author.php
+++ b/templates/json-author.php
@@ -43,7 +43,7 @@ $json->publicKey = array(
 $json->tag = array();
 $json->attachment = array();
 
-$json->attachment[] = array(
+$json->attachment['blog'] = array(
 	'type' => 'PropertyValue',
 	'name' => __( 'Blog', 'activitypub' ),
 	'value' => html_entity_decode(
@@ -53,7 +53,7 @@ $json->attachment[] = array(
 	),
 );
 
-$json->attachment[] = array(
+$json->attachment['profile'] = array(
 	'type' => 'PropertyValue',
 	'name' => __( 'Profile', 'activitypub' ),
 	'value' => html_entity_decode(
@@ -64,7 +64,7 @@ $json->attachment[] = array(
 );
 
 if ( get_the_author_meta( 'user_url', $author_id ) ) {
-	$json->attachment[] = array(
+	$json->attachment['website'] = array(
 		'type' => 'PropertyValue',
 		'name' => __( 'Website', 'activitypub' ),
 		'value' => html_entity_decode(
@@ -81,6 +81,9 @@ if ( get_the_author_meta( 'user_url', $author_id ) ) {
 
 // filter output
 $json = apply_filters( 'activitypub_json_author_array', $json );
+
+// get rid of all attachment array keys
+$json->attachment = array_values( $json->attachment );
 
 /*
  * Action triggerd prior to the ActivityPub profile being created and sent to the client


### PR DESCRIPTION
This allows easier filtering of attached `PropertyValue` fields.
A step towards allowing a plugin to be developed that makes #33 super easy for users to configure themselves.

(An alternative would be to add individual filters for all parts of the author array, instead of just the main one)

So using a filter like this:
```php
add_filter( 'activitypub_json_author_array', function($json) {

        // Don't show the Blog URL.
        unset($json->attachment['blog']);

        // Add a custom field.
        $json->attachment[] = array(
                'type'  => 'PropertyValue',
                'name'  => 'Coding...',
                'value' => '...for the World!',
        );

	return $json;
} );
```

Gives something like this:
![mastodon-profile](https://user-images.githubusercontent.com/9423417/61594730-b0465700-abde-11e9-8252-d56384ae5abe.png)