### PR TITLE
Only return nodeinfo data if site is public

### DIFF
--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -13,7 +13,7 @@ class Nodeinfo {
 	 * Initialize the class, registering WordPress hooks
 	 */
 	public static function init() {
-		if ( 1 === get_option('blog_public') ) {
+		if ( 1 === get_option( 'blog_public', 1 ) ) {
 			\add_action( 'rest_api_init', array( '\Activitypub\Rest\Nodeinfo', 'register_routes' ) );
 			\add_filter( 'nodeinfo_data', array( '\Activitypub\Rest\Nodeinfo', 'add_nodeinfo_discovery' ), 10, 2 );
 			\add_filter( 'nodeinfo2_data', array( '\Activitypub\Rest\Nodeinfo', 'add_nodeinfo2_discovery' ), 10 );

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -13,9 +13,11 @@ class Nodeinfo {
 	 * Initialize the class, registering WordPress hooks
 	 */
 	public static function init() {
-		\add_action( 'rest_api_init', array( '\Activitypub\Rest\Nodeinfo', 'register_routes' ) );
-		\add_filter( 'nodeinfo_data', array( '\Activitypub\Rest\Nodeinfo', 'add_nodeinfo_discovery' ), 10, 2 );
-		\add_filter( 'nodeinfo2_data', array( '\Activitypub\Rest\Nodeinfo', 'add_nodeinfo2_discovery' ), 10 );
+		if ( 1 === get_option('blog_public') ) {
+			\add_action( 'rest_api_init', array( '\Activitypub\Rest\Nodeinfo', 'register_routes' ) );
+			\add_filter( 'nodeinfo_data', array( '\Activitypub\Rest\Nodeinfo', 'add_nodeinfo_discovery' ), 10, 2 );
+			\add_filter( 'nodeinfo2_data', array( '\Activitypub\Rest\Nodeinfo', 'add_nodeinfo2_discovery' ), 10 );
+		}
 	}
 
 	/**
@@ -89,6 +91,9 @@ class Nodeinfo {
 		$nodeinfo['metadata'] = array(
 			'email' => \get_option( 'admin_email' ),
 		);
+
+		$nodeinfo['blog_public'] = array(
+			'blog_public' =>  \get_option('blog_public') );
 
 		return new \WP_REST_Response( $nodeinfo, 200 );
 	}

--- a/includes/rest/class-nodeinfo.php
+++ b/includes/rest/class-nodeinfo.php
@@ -92,9 +92,6 @@ class Nodeinfo {
 			'email' => \get_option( 'admin_email' ),
 		);
 
-		$nodeinfo['blog_public'] = array(
-			'blog_public' =>  \get_option('blog_public') );
-
 		return new \WP_REST_Response( $nodeinfo, 200 );
 	}
 


### PR DESCRIPTION
Give nodeinfo services the same indexing privileges as web crawlers based on the wordpress setting `blog_public` :
> Discourage search engines from indexing this site

If the option is enabled, the nodeinfo path returns a 404 error as per the [protocol](https://github.com/jhass/nodeinfo/blob/master/PROTOCOL.md)