### PR TITLE
Respect the intent of site discussion settings

### DIFF
--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -265,6 +265,13 @@ class Inbox {
 
 		$state = \wp_new_comment( $commentdata, true );
 
+		if ( 1 == get_option( 'require_name_email', 1 ) ) {
+			\wp_set_comment_status( $state, 'hold' );
+		}
+		if ( 1 == get_option( 'comment_registration', 0 ) ) {
+			\wp_set_comment_status( $state, 'hold' );
+		}
+
 		// re-add flood control
 		\add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );
 	}


### PR DESCRIPTION
Opening, to discuss whether these settings are relevant or not to comments originating from ActivityPub.

- Comment author must fill out name and email 
- Users must be registered and logged in to comment 

After testing, the two settings don't seem to be considered within `wp_new_comment()`.
The approach holds the comments for moderation, instead of outright allowing them.

Should we assume that users would give preference to ActivityPub replies over traditional forms?
Or should we let users decide via a plugin setting?
