### PR TITLE
Fix timezone

### DIFF
--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -46,7 +46,7 @@ class Post {
 		$array = array(
 			'id' => $this->id,
 			'type' => $this->object_type,
-			'published' => \date( 'Y-m-d\TH:i:s\Z', \strtotime( $post->post_date ) ),
+			'published' => \date( 'Y-m-d\TH:i:s\Z', \strtotime( $post->post_date_gmt ) ),
 			'attributedTo' => \get_author_posts_url( $post->post_author ),
 			'summary' => $this->summary,
 			'inReplyTo' => null,


### PR DESCRIPTION
In my own testing, I have found that the post timezone was skewed by its distance from GMT.
WordPress post object includes a timezone neutral `post_date_gmt`, using this allows peers to display the correct post date-time. 
#63