### PR TITLE
Link to a GNU Social fork that is under active development

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,7 @@ To implement:
 
 = What is "ActivityPub for WordPress" =
 
-*ActivityPub for WordPress* extends WordPress with some Fediverse features, but it does not compete with platforms like Friendica or Mastodon. If you want to run a **decentralized social network**, please use [Mastodon](https://joinmastodon.org/) or [GNU social](https://gnu.io/social/).
+*ActivityPub for WordPress* extends WordPress with some Fediverse features, but it does not compete with platforms like Friendica or Mastodon. If you want to run a **decentralized social network**, please use [Mastodon](https://joinmastodon.org/) or [GNU social](https://gnusocial.network/).
 
 = What are the differences between this plugin and Pterotype? =
 


### PR DESCRIPTION
What you can find on https://gnu.io/social doesn't even support ActivityPub.