### PR TITLE
Fix public addressing

### DIFF
--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -31,7 +31,8 @@ class Activity_Dispatcher {
 		$activitypub_activity->from_post( $activitypub_post->to_array() );
 
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
-			$activitypub_activity->set_to( $to );
+			$activitypub_activity->set_to( 'https://www.w3.org/ns/activitystreams#Public' );
+			$activitypub_activity->set_cc( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
 
 			\Activitypub\safe_remote_post( $inbox, $activity, $user_id );
@@ -51,7 +52,8 @@ class Activity_Dispatcher {
 		$activitypub_activity->from_post( $activitypub_post->to_array() );
 
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
-			$activitypub_activity->set_to( $to );
+			$activitypub_activity->set_to( 'https://www.w3.org/ns/activitystreams#Public' );
+			$activitypub_activity->set_cc( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
 
 			\Activitypub\safe_remote_post( $inbox, $activity, $user_id );
@@ -71,7 +73,8 @@ class Activity_Dispatcher {
 		$activitypub_activity->from_post( $activitypub_post->to_array() );
 
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
-			$activitypub_activity->set_to( $to );
+			$activitypub_activity->set_to( 'https://www.w3.org/ns/activitystreams#Public' );
+			$activitypub_activity->set_cc( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
 
 			\Activitypub\safe_remote_post( $inbox, $activity, $user_id );

--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -31,7 +31,6 @@ class Activity_Dispatcher {
 		$activitypub_activity->from_post( $activitypub_post->to_array() );
 
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
-			$activitypub_activity->set_to( 'https://www.w3.org/ns/activitystreams#Public' );
 			$activitypub_activity->set_cc( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
 
@@ -52,7 +51,6 @@ class Activity_Dispatcher {
 		$activitypub_activity->from_post( $activitypub_post->to_array() );
 
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
-			$activitypub_activity->set_to( 'https://www.w3.org/ns/activitystreams#Public' );
 			$activitypub_activity->set_cc( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
 
@@ -73,7 +71,6 @@ class Activity_Dispatcher {
 		$activitypub_activity->from_post( $activitypub_post->to_array() );
 
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
-			$activitypub_activity->set_to( 'https://www.w3.org/ns/activitystreams#Public' );
 			$activitypub_activity->set_cc( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
 


### PR DESCRIPTION
Public activities are addressed to the special Public collection in the `to` field, individual recipients are added to the `cc` field

A reference to the Followers collection could be added to the `to` field, but I'm not sure it's needed at the moment.

 #114 