### PR TITLE
Prevent comments being flagged as spam by akismet

### DIFF
--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -383,7 +383,12 @@ class Inbox {
 		// do not require email for AP entries
 		\add_filter( 'pre_option_require_name_email', '__return_false' );
 
+		// disable akismet if necessary
+		\add_filter( 'akismet_get_api_key', '__return_null');
+
 		$state = \wp_new_comment( $commentdata, true );
+
+		\remove_filter( 'akismet_get_api_key', '__return_null');
 
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
 
@@ -427,9 +432,12 @@ class Inbox {
 
 		// do not require email for AP entries
 		\add_filter( 'pre_option_require_name_email', '__return_false' );
+		// disable akismet if necessary
+		\add_filter( 'akismet_get_api_key', '__return_null');
 
 		$state = \wp_new_comment( $commentdata, true );
 
+		\remove_filter( 'akismet_get_api_key', '__return_null');
 		\remove_filter( 'pre_option_require_name_email', '__return_false' );
 
 		// re-add flood control


### PR DESCRIPTION
It's very difficult to get akismet to approve of a mechanically posted
comment because all the various capchas and java script tests have to
pass.  So, instead of trying to make everything right, simply turn off
akismet for Activitypub comments (this means you should set your
default policy to moderate all comments which don't have one approved
just in case some bot works out how to spam via activitypub).

Signed-off-by: James Bottomley <James.Bottomley@HansenPartnership.com>