### PR TITLE
fix for #192

### DIFF
--- a/includes/rest/class-inbox.php
+++ b/includes/rest/class-inbox.php
@@ -327,7 +327,7 @@ class Inbox {
 		\Activitypub\Peer\Followers::add_follower( $object['actor'], $user_id );
 
 		// get inbox
-		$inbox = \Activitypub\get_inbox_by_actor( $object['actor'] );
+		$inbox = \Activitypub\get_inbox_by_actor( $object['object'] );
 
 		// send "Accept" activity
 		$activity = new \Activitypub\Model\Activity( 'Accept', \Activitypub\Model\Activity::TYPE_SIMPLE );


### PR DESCRIPTION
Object of class WP_Error could not be converted to string #192

https://github.com/pfefferle/wordpress-activitypub/issues/192