### PR TITLE
prepare 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ActivityPub #
-**Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/)  
+**Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle/), [mediaformat](https://profiles.wordpress.org/mediaformat/), [akirk](https://profiles.wordpress.org/akirk/)  
 **Donate link:** https://notiz.blog/donate/  
 **Tags:** OStatus, fediverse, activitypub, activitystream  
 **Requires at least:** 4.7  
-**Tested up to:** 6.0  
-**Stable tag:** 0.13.4  
+**Tested up to:** 6.1  
+**Stable tag:** 0.14.0  
 **Requires PHP:** 5.6  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
@@ -87,6 +87,14 @@ Where 'blog' is the path to the subdirectory at which your blog resides.
 ## Changelog ##
 
 Project maintained on GitHub at [pfefferle/wordpress-activitypub](https://github.com/pfefferle/wordpress-activitypub).
+
+### 0.14.0 ###
+
+* Friends support: https://wordpress.org/plugins/friends/ props [@akirk](https://github.com/akirk)
+* Massive guidance improvements. props [mediaformat](https://github.com/mediaformat) & [@akirk](https://github.com/akirk)
+* Add Custom Post Type support to outbox API. props [blueset](https://github.com/blueset)
+* Better hash-tag support. props [bocops](https://github.com/bocops)
+* Fix user-count (NodeInfo). props [mediaformat](https://github.com/mediaformat)
 
 ### 0.13.4 ###
 

--- a/activitypub.php
+++ b/activitypub.php
@@ -3,7 +3,7 @@
  * Plugin Name: ActivityPub
  * Plugin URI: https://github.com/pfefferle/wordpress-activitypub/
  * Description: The ActivityPub protocol is a decentralized social networking protocol based upon the ActivityStreams 2.0 data format.
- * Version: 0.13.4
+ * Version: 0.14.0
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
  * License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === ActivityPub ===
-Contributors: pfefferle, mediaformat
+Contributors: pfefferle, mediaformat, akirk
 Donate link: https://notiz.blog/donate/
 Tags: OStatus, fediverse, activitypub, activitystream
 Requires at least: 4.7
-Tested up to: 6.0
-Stable tag: 0.13.4
+Tested up to: 6.1
+Stable tag: 0.14.0
 Requires PHP: 5.6
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -87,6 +87,14 @@ Where 'blog' is the path to the subdirectory at which your blog resides.
 == Changelog ==
 
 Project maintained on GitHub at [pfefferle/wordpress-activitypub](https://github.com/pfefferle/wordpress-activitypub).
+
+= 0.14.0 =
+
+* Friends support: https://wordpress.org/plugins/friends/ props [@akirk](https://github.com/akirk)
+* Massive guidance improvements. props [mediaformat](https://github.com/mediaformat) & [@akirk](https://github.com/akirk)
+* Add Custom Post Type support to outbox API. props [blueset](https://github.com/blueset)
+* Better hash-tag support. props [bocops](https://github.com/bocops)
+* Fix user-count (NodeInfo). props [mediaformat](https://github.com/mediaformat)
 
 = 0.13.4 =
 


### PR DESCRIPTION
next release fokus: https://github.com/pfefferle/wordpress-activitypub/pull/142