### PR TITLE
Issue 214

### DIFF
--- a/includes/rest/class-webfinger.php
+++ b/includes/rest/class-webfinger.php
@@ -44,16 +44,15 @@ class Webfinger {
 	public static function webfinger( $request ) {
 		$resource = $request->get_param( 'resource' );
 
-		$matched = \str_contains( $resource, '@' );
+		$matches = array();
+		$matched = \preg_match( '/^acct:([^@]+)@(.+)$/', $resource, $matches );
 
 		if ( ! $matched ) {
 			return new \WP_Error( 'activitypub_unsupported_resource', \__( 'Resource is invalid', 'activitypub' ), array( 'status' => 400 ) );
 		}
 
-		$resource = \str_replace( 'acct:', '', $resource );
-
-		$resource_identifier = \substr( $resource, 0, \strrpos( $resource, '@' ) );
-		$resource_host = \substr( \strrchr( $resource, '@' ), 1 );
+		$resource_identifier = $matches[1];
+		$resource_host = $matches[2];
 
 		if ( \wp_parse_url( \home_url( '/' ), \PHP_URL_HOST ) !== $resource_host ) {
 			return new \WP_Error( 'activitypub_wrong_host', \__( 'Resource host does not match blog host', 'activitypub' ), array( 'status' => 404 ) );
@@ -98,7 +97,7 @@ class Webfinger {
 		$params['resource'] = array(
 			'required' => true,
 			'type' => 'string',
-			'pattern' => '^acct:(.+)@(.+)$',
+			'pattern' => '^acct:([^@]+)@(.+)$',
 		);
 
 		return $params;

--- a/includes/rest/class-webfinger.php
+++ b/includes/rest/class-webfinger.php
@@ -45,7 +45,7 @@ class Webfinger {
 		$resource = $request->get_param( 'resource' );
 
 		$matches = array();
-		$matched = \preg_match( '/^acct:([^@]+)@(.+)$/', $resource, $matches );
+		$matched = \preg_match( '/^acct:(.+)@([^@]+)$/', $resource, $matches );
 
 		if ( ! $matched ) {
 			return new \WP_Error( 'activitypub_unsupported_resource', \__( 'Resource is invalid', 'activitypub' ), array( 'status' => 400 ) );
@@ -97,7 +97,7 @@ class Webfinger {
 		$params['resource'] = array(
 			'required' => true,
 			'type' => 'string',
-			'pattern' => '^acct:([^@]+)@(.+)$',
+			'pattern' => '^acct:(.+)@([^@]+)$',
 		);
 
 		return $params;


### PR DESCRIPTION
This reverts the previous fix to #152, and replaces it with a new implementation that is compatible with PHP 7.4 and therefore fixes #214.  Or at least, I think this fixes #152.  This has not been extensively tested.  All I did was change the regex `([^@]+)@(.+)` to `(.+)@([^@]+)`, so that the last at-sign will be the separator instead of the first.  So perhaps treat it as a suggestion.