### PR TITLE
Don't access transient when receiving a WP_Error

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -118,6 +118,10 @@ function get_remote_metadata_by_actor( $actor ) {
 		return null;
 	}
 
+	if ( is_wp_error( $actor ) ) {
+		return $actor;
+	}
+
 	$metadata = \get_transient( 'activitypub_' . $actor );
 
 	if ( $metadata ) {

--- a/integration/class-friends-feed-parser-activitypub.php
+++ b/integration/class-friends-feed-parser-activitypub.php
@@ -68,7 +68,7 @@ class Friends_Feed_Parser_ActivityPub extends \Friends\Feed_Parser {
 	 */
 	public function update_feed_details( $feed_details ) {
 		$meta = \Activitypub\get_remote_metadata_by_actor( $feed_details['url'] );
-		if ( ! $meta && is_wp_error( $meta ) ) {
+		if ( ! $meta || is_wp_error( $meta ) ) {
 			return $meta;
 		}
 


### PR DESCRIPTION
Fixes #219 which exposes a bug where we try to use a WP_Error to create a transient key.