### PR TITLE
support threaded comments from ActivityPub

### DIFF
--- a/includes/class-activity-dispatcher.php
+++ b/includes/class-activity-dispatcher.php
@@ -33,6 +33,7 @@ class Activity_Dispatcher {
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
 			$activitypub_activity->set_to( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
+			\error_log("@@@ send_post_activity: inbox " . $inbox . " user id " . $user_id . " activity " . $activity);
 
 			\Activitypub\safe_remote_post( $inbox, $activity, $user_id );
 		}
@@ -53,6 +54,7 @@ class Activity_Dispatcher {
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
 			$activitypub_activity->set_to( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
+			\error_log("@@@ send_update_activity: inbox " . $inbox . " user id " . $user_id . " activity " . $activity);
 
 			\Activitypub\safe_remote_post( $inbox, $activity, $user_id );
 		}
@@ -73,6 +75,7 @@ class Activity_Dispatcher {
 		foreach ( \Activitypub\get_follower_inboxes( $user_id ) as $inbox => $to ) {
 			$activitypub_activity->set_to( $to );
 			$activity = $activitypub_activity->to_json(); // phpcs:ignore
+			\error_log("@@@ send_delete_activity: inbox " . $inbox . " user id " . $user_id . " activity " . $activity);
 
 			\Activitypub\safe_remote_post( $inbox, $activity, $user_id );
 		}


### PR DESCRIPTION
This change supports replies to comments as threaded comments in wordpress.  It implements #233.

Originally I planned to get the post ID from the `context`.  However, it turns out only older versions of Friendica populate that field.  So instead I have to get it by looking up the comment with `inReplyTo`.  I left the support for `context` in there in case other ActivityPub actors use it that way.  Otherwise it's not always possible to correctly thread together replies that are out of order.