### PR TITLE
Add new template patterns

### DIFF
--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -228,6 +228,18 @@ class Post {
 		$content = \str_replace( '%permalink%', $this->get_the_post_link( 'permalink' ), $content );
 		$content = \str_replace( '%shortlink%', $this->get_the_post_link( 'shortlink' ), $content );
 		$content = \str_replace( '%hashtags%', $this->get_the_post_hashtags(), $content );
+		$content = \str_replace( '%thumbnail%', $this->get_the_post_image( 'thumbnail' ), $content );
+		$content = \str_replace( '%image%', $this->get_the_post_image(), $content );
+		$content = \str_replace( '%hashcats%', $this->get_the_post_categories(), $content );
+		$content = \str_replace( '%author%', $this->get_the_post_author(), $content );
+		$content = \str_replace( '%authorurl%', $this->get_the_post_author_url(), $content );
+		$content = \str_replace( '%blogurl%', \bloginfo('url'), $content );
+		$content = \str_replace( '%blogname%', \bloginfo('name'), $content );
+		$content = \str_replace( '%blogdesc%', \bloginfo('description'), $content );
+		$content = \str_replace( '%date%', $this->get_the_post_datetime( 'time' ), $content );
+		$content = \str_replace( '%time%', $this->get_the_post_time( 'date' ), $content );
+		$content = \str_replace( '%datetime%', $this->get_the_post_time( 'both' ), $content );
+
 		// backwards compatibility
 		$content = \str_replace( '%tags%', $this->get_the_post_hashtags(), $content );
 
@@ -353,4 +365,112 @@ class Post {
 
 		return \implode( ' ', $hash_tags );
 	}
+
+	/**
+	 * Adds the featured image url to the post/summary content
+	 *
+	 * @param string  $size
+	 *
+	 * @return string
+	 */
+	public function get_the_post_image( $size = 'full' ) {
+		$post = $this->post;
+
+		if( $size == '' ) { $size = 'full'; }
+
+		$image = \get_the_post_thumbnail_url( $post->ID, $size );
+
+		if ( ! $image ) {
+			return '';
+		}
+
+		return $image;
+	}
+
+	/**
+	 * Adds all categories as hashtags to the post/summary content
+	 *
+	 * @return string
+	 */
+	public function get_the_post_categories() {
+		$post = $this->post;
+		$categories = \get_the_category( $post->ID );
+
+		if ( ! $categories ) {
+			return '';
+		}
+
+		$hash_tags = array();
+
+		foreach ( $categories as $category ) {
+			$hash_tags[] = \sprintf( '<a rel="tag" class="u-tag u-category" href="%s">#%s</a>', \get_category_link( $category ), $category->slug );
+		}
+
+		return \implode( ' ', $hash_tags );
+	}
+
+	/**
+	 * Adds author to the post/summary content
+	 *
+	 * @return string
+	 */
+	public function get_the_post_author() {
+		$post = $this->post;
+		$name = \get_the_author_meta( 'display_name', $post->post_author );
+
+		if ( ! $name ) {
+			return '';
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Adds author's url to the post/summary content
+	 *
+	 * @return string
+	 */
+	public function get_the_post_profile_url() {
+		$post = $this->post;
+		$url = \get_the_author_meta( 'user_url', $post->post_author );
+
+		if ( ! $url ) {
+			return '';
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Adds the post date/time to the post/summary content
+	 *
+	 * @param string display
+	 *
+	 * @return string
+	 */
+	public function get_the_post_date( $display = 'both' ) {
+		$post = $this->post;
+		$datetime = \get_post_datetime( $post_id );
+		$dateformat = \get_option( 'date_format' );
+		$timeformat = \get_option( 'time_format' );
+
+		switch( $display ) {
+			case 'date':
+				$date = $datetime->format( $dateformat );
+				break;
+			case 'time':
+				$date = $datetime->format( $timeformat );
+				break;
+			default:
+				$date = $datetime->format( $dateformat . ' @ ' . $timeformat );
+				break;
+		}
+
+		if ( ! $date ) {
+			return '';
+		}
+
+		return $date;
+	}
+
 }

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -314,8 +314,7 @@ class Post {
 	/**
 	 * Adds a backlink to the post/summary content
 	 *
-	 * @param string  $content
-	 * @param WP_Post $post
+	 * @param string  $type
 	 *
 	 * @return string
 	 */
@@ -335,9 +334,6 @@ class Post {
 
 	/**
 	 * Adds all tags as hashtags to the post/summary content
-	 *
-	 * @param string  $content
-	 * @param WP_Post $post
 	 *
 	 * @return string
 	 */

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -233,9 +233,9 @@ class Post {
 		$content = \str_replace( '%hashcats%', $this->get_the_post_categories(), $content );
 		$content = \str_replace( '%author%', $this->get_the_post_author(), $content );
 		$content = \str_replace( '%authorurl%', $this->get_the_post_author_url(), $content );
-		$content = \str_replace( '%blogurl%', \bloginfo('url'), $content );
-		$content = \str_replace( '%blogname%', \bloginfo('name'), $content );
-		$content = \str_replace( '%blogdesc%', \bloginfo('description'), $content );
+		$content = \str_replace( '%blogurl%', \get_bloginfo('url'), $content );
+		$content = \str_replace( '%blogname%', \get_bloginfo('name'), $content );
+		$content = \str_replace( '%blogdesc%', \get_bloginfo('description'), $content );
 		$content = \str_replace( '%date%', $this->get_the_post_datetime( 'time' ), $content );
 		$content = \str_replace( '%time%', $this->get_the_post_time( 'date' ), $content );
 		$content = \str_replace( '%datetime%', $this->get_the_post_time( 'both' ), $content );

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -59,13 +59,13 @@
 								<summary><?php esc_html_e( 'See the complete list of template patterns.', 'activitypub' ); ?></summary>
 								<div class="description">
 									<ul>
-										<li><code>%title%</code> - <?php \esc_html_e( 'The Post-Title.', 'activitypub' ); ?></li>
-										<li><code>%content%</code> - <?php \esc_html_e( 'The Post-Content.', 'activitypub' ); ?></li>
-										<li><code>%excerpt%</code> - <?php \esc_html_e( 'The Post-Excerpt (default 400 Chars).', 'activitypub' ); ?></li>
-										<li><code>%permalink%</code> - <?php \esc_html_e( 'The Post-Permalink.', 'activitypub' ); ?></li>
+										<li><code>%title%</code> - <?php \esc_html_e( 'The post\'s title.', 'activitypub' ); ?></li>
+										<li><code>%content%</code> - <?php \esc_html_e( 'The post\'s content.', 'activitypub' ); ?></li>
+										<li><code>%excerpt%</code> - <?php \esc_html_e( 'The post\'s excerpt (default 400 Chars).', 'activitypub' ); ?></li>
+										<li><code>%permalink%</code> - <?php \esc_html_e( 'The post\'s permalink.', 'activitypub' ); ?></li>
 										<?php // translators: ?>
-										<li><code>%shortlink%</code> - <?php echo \wp_kses( \__( 'The Post-Shortlink. I can recommend <a href="https://wordpress.org/plugins/hum/" target="_blank">Hum</a>, to prettify the Shortlinks', 'activitypub' ), 'default' ); ?></li>
-										<li><code>%hashtags%</code> - <?php \esc_html_e( 'The Tags as Hashtags.', 'activitypub' ); ?></li>
+										<li><code>%shortlink%</code> - <?php echo \wp_kses( \__( 'The post\'s shortlink. I can recommend <a href="https://wordpress.org/plugins/hum/" target="_blank">Hum</a>, to prettify the Shortlinks', 'activitypub' ), 'default' ); ?></li>
+										<li><code>%hashtags%</code> - <?php \esc_html_e( 'The post\'s tags as hashtags.', 'activitypub' ); ?></li>
 									</ul>
 								</div>
 							</details>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -7,6 +7,10 @@
 		'welcome' => '',
 	)
 );
+
+$image_sizes = wp_get_registered_image_subsizes();
+$thumnail_size = $image_sizes['thumbnail']['width'] . 'px X ' . $image_sizes['thumbnail']['height'] . 'px';
+
 ?>
 
 <div class="privacy-settings-body hide-if-no-js">
@@ -66,6 +70,17 @@
 										<?php // translators: ?>
 										<li><code>%shortlink%</code> - <?php echo \wp_kses( \__( 'The post\'s shortlink. I can recommend <a href="https://wordpress.org/plugins/hum/" target="_blank">Hum</a>, to prettify the Shortlinks', 'activitypub' ), 'default' ); ?></li>
 										<li><code>%hashtags%</code> - <?php \esc_html_e( 'The post\'s tags as hashtags.', 'activitypub' ); ?></li>
+										<li><code>%hashcats%</code> - <?php \esc_html_e( 'The post\'s categories as hashtags.', 'activitypub' ); ?></li>
+										<li><code>%image%</code> - <?php \esc_html_e( 'The URL for the post\'s featured image, full size.', 'activitypub' ); ?></li>
+										<li><code>%thumbnail%</code> - <?php echo \wp_kses( sprintf( __( 'The URL for the post\'s featured image thumbnail size (%s).', 'activitypub'), $thumnail_size ), 'default' ); ?></li>
+										<li><code>%author%</code> - <?php \esc_html_e( 'The author\'s name.', 'activitypub' ); ?></li>
+										<li><code>%authorurl%</code> - <?php \esc_html_e( 'The URL to the author\'s profile page.', 'activitypub' ); ?></li>
+										<li><code>%date%</code> - <?php \esc_html_e( 'The post\'s date.', 'activitypub' ); ?></li>
+										<li><code>%time%</code> - <?php \esc_html_e( 'The post\'s time.', 'activitypub' ); ?></li>
+										<li><code>%datetime%</code> - <?php \esc_html_e( 'The post\'s date/time formated as "date @ time".', 'activitypub' ); ?></li>
+										<li><code>%blogurl%</code> - <?php \esc_html_e( 'The URL to the site.', 'activitypub' ); ?></li>
+										<li><code>%blogname%</code> - <?php \esc_html_e( 'The name of the site.', 'activitypub' ); ?></li>
+										<li><code>%blogdesc%</code> - <?php \esc_html_e( 'The description of the site.', 'activitypub' ); ?></li>
 									</ul>
 								</div>
 							</details>


### PR DESCRIPTION
This PR adds the following new template patterns:

- %hashcats% - The post's categories as hashtags
- %image% - The URL for the post's featured image, full size
- %thumbnail% - The URL for the post's featured image thumbnail size
- %author% - The author's name
- %authorurl% - The URL to the author's profile page
- %date% - The post's date
- %time% - The post's time
- %datetime% - The post's date/time formated as "date @ time"
- %blogurl% - The URL to the site
- %blogname% - The name of the site
- %blogdesc% - The description of the site

In additon it cleans up a few gramatical and param definitions associated with the origial template patterns.

Resolves #243