### PR TITLE
configuration item for number of images to attach

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -19,7 +19,7 @@ namespace Activitypub;
  * Initialize plugin
  */
 function init() {
-	\defined( 'ACTIVITYPUB_NUMBER_IMAGES' ) || \define( 'ACTIVITYPUB_NUMBER_IMAGES', 3 );
+	\defined( 'ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS' ) || \define( 'ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS', 3 );
 	\defined( 'ACTIVITYPUB_HASHTAGS_REGEXP' ) || \define( 'ACTIVITYPUB_HASHTAGS_REGEXP', '(?:(?<=\s)|(?<=<p>)|(?<=<br>)|^)#([A-Za-z0-9_]+)(?:(?=\s|[[:punct:]]|$))' );
 	\defined( 'ACTIVITYPUB_ALLOWED_HTML' ) || \define( 'ACTIVITYPUB_ALLOWED_HTML', '<strong><a><p><ul><ol><li><code><blockquote><pre><img>' );
 	\defined( 'ACTIVITYPUB_CUSTOM_POST_CONTENT' ) || \define( 'ACTIVITYPUB_CUSTOM_POST_CONTENT', "<p><strong>%title%</strong></p>\n\n%content%\n\n<p>%hashtags%</p>\n\n<p>%shortlink%</p>" );

--- a/activitypub.php
+++ b/activitypub.php
@@ -19,6 +19,7 @@ namespace Activitypub;
  * Initialize plugin
  */
 function init() {
+	\defined( 'ACTIVITYPUB_NUMBER_IMAGES' ) || \define( 'ACTIVITYPUB_NUMBER_IMAGES', 3 );
 	\defined( 'ACTIVITYPUB_HASHTAGS_REGEXP' ) || \define( 'ACTIVITYPUB_HASHTAGS_REGEXP', '(?:(?<=\s)|(?<=<p>)|(?<=<br>)|^)#([A-Za-z0-9_]+)(?:(?=\s|[[:punct:]]|$))' );
 	\defined( 'ACTIVITYPUB_ALLOWED_HTML' ) || \define( 'ACTIVITYPUB_ALLOWED_HTML', '<strong><a><p><ul><ol><li><code><blockquote><pre><img>' );
 	\defined( 'ACTIVITYPUB_CUSTOM_POST_CONTENT' ) || \define( 'ACTIVITYPUB_CUSTOM_POST_CONTENT', "<p><strong>%title%</strong></p>\n\n%content%\n\n<p>%hashtags%</p>\n\n<p>%shortlink%</p>" );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -100,6 +100,15 @@ class Admin {
 		);
 		\register_setting(
 			'activitypub',
+			'activitypub_number_images',
+			array(
+				'type' => 'integer',
+				'description' => \__( 'Number of images to attach to posts.', 'activitypub' ),
+				'default' => ACTIVITYPUB_NUMBER_IMAGES,
+			)
+		);
+		\register_setting(
+			'activitypub',
 			'activitypub_object_type',
 			array(
 				'type' => 'string',

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -100,11 +100,11 @@ class Admin {
 		);
 		\register_setting(
 			'activitypub',
-			'activitypub_number_images',
+			'activitypub_max_image_attachments',
 			array(
 				'type' => 'integer',
 				'description' => \__( 'Number of images to attach to posts.', 'activitypub' ),
-				'default' => ACTIVITYPUB_NUMBER_IMAGES,
+				'default' => ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS,
 			)
 		);
 		\register_setting(

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -82,7 +82,7 @@ class Post {
 
 		// max images can't be negative or zero
 		if ( $max_images <= 0 ) {
-			$max_images = 1;
+			return $images;
 		}
 
 		$id = $this->post->ID;
@@ -94,22 +94,20 @@ class Post {
 			$max_images--;
 		}
 		// then list any image attachments
-		if ( $max_images > 0 ) {
-			$query = new \WP_Query(
-				array(
-					'post_parent' => $id,
-					'post_status' => 'inherit',
-					'post_type' => 'attachment',
-					'post_mime_type' => 'image',
-					'order' => 'ASC',
-					'orderby' => 'menu_order ID',
-					'posts_per_page' => $max_images,
-				)
-			);
-			foreach ( $query->get_posts() as $attachment ) {
-				if ( ! \in_array( $attachment->ID, $image_ids, true ) ) {
-					$image_ids[] = $attachment->ID;
-				}
+		$query = new \WP_Query(
+			array(
+				'post_parent' => $id,
+				'post_status' => 'inherit',
+				'post_type' => 'attachment',
+				'post_mime_type' => 'image',
+				'order' => 'ASC',
+				'orderby' => 'menu_order ID',
+				'posts_per_page' => $max_images,
+			)
+		);
+		foreach ( $query->get_posts() as $attachment ) {
+			if ( ! \in_array( $attachment->ID, $image_ids, true ) ) {
+				$image_ids[] = $attachment->ID;
 			}
 		}
 

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -76,7 +76,7 @@ class Post {
 	}
 
 	public function generate_attachments() {
-		$max_images = intval( \apply_filters( 'activitypub_max_images', \get_option( 'activitypub_number_images', ACTIVITYPUB_NUMBER_IMAGES ) ) );
+		$max_images = intval( \apply_filters( 'activitypub_max_image_attachments', \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) ) );
 
 		$images = array();
 

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -88,26 +88,30 @@ class Post {
 		$id = $this->post->ID;
 
 		$image_ids = array();
+
 		// list post thumbnail first if this post has one
 		if ( \function_exists( 'has_post_thumbnail' ) && \has_post_thumbnail( $id ) ) {
 			$image_ids[] = \get_post_thumbnail_id( $id );
 			$max_images--;
 		}
-		// then list any image attachments
-		$query = new \WP_Query(
-			array(
-				'post_parent' => $id,
-				'post_status' => 'inherit',
-				'post_type' => 'attachment',
-				'post_mime_type' => 'image',
-				'order' => 'ASC',
-				'orderby' => 'menu_order ID',
-				'posts_per_page' => $max_images,
-			)
-		);
-		foreach ( $query->get_posts() as $attachment ) {
-			if ( ! \in_array( $attachment->ID, $image_ids, true ) ) {
-				$image_ids[] = $attachment->ID;
+
+		if ( $max_images > 0 ) {
+			// then list any image attachments
+			$query = new \WP_Query(
+				array(
+					'post_parent' => $id,
+					'post_status' => 'inherit',
+					'post_type' => 'attachment',
+					'post_mime_type' => 'image',
+					'order' => 'ASC',
+					'orderby' => 'menu_order ID',
+					'posts_per_page' => $max_images,
+				)
+			);
+			foreach ( $query->get_posts() as $attachment ) {
+				if ( ! \in_array( $attachment->ID, $image_ids, true ) ) {
+					$image_ids[] = $attachment->ID;
+				}
 			}
 		}
 

--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -76,7 +76,7 @@ class Post {
 	}
 
 	public function generate_attachments() {
-		$max_images = \apply_filters( 'activitypub_max_images', 3 );
+		$max_images = intval( \apply_filters( 'activitypub_max_images', \get_option( 'activitypub_number_images', ACTIVITYPUB_NUMBER_IMAGES ) ) );
 
 		$images = array();
 
@@ -94,20 +94,22 @@ class Post {
 			$max_images--;
 		}
 		// then list any image attachments
-		$query = new \WP_Query(
-			array(
-				'post_parent' => $id,
-				'post_status' => 'inherit',
-				'post_type' => 'attachment',
-				'post_mime_type' => 'image',
-				'order' => 'ASC',
-				'orderby' => 'menu_order ID',
-				'posts_per_page' => $max_images,
-			)
-		);
-		foreach ( $query->get_posts() as $attachment ) {
-			if ( ! \in_array( $attachment->ID, $image_ids, true ) ) {
-				$image_ids[] = $attachment->ID;
+		if ( $max_images > 0 ) {
+			$query = new \WP_Query(
+				array(
+					'post_parent' => $id,
+					'post_status' => 'inherit',
+					'post_type' => 'attachment',
+					'post_mime_type' => 'image',
+					'order' => 'ASC',
+					'orderby' => 'menu_order ID',
+					'posts_per_page' => $max_images,
+				)
+			);
+			foreach ( $query->get_posts() as $attachment ) {
+				if ( ! \in_array( $attachment->ID, $image_ids, true ) ) {
+					$image_ids[] = $attachment->ID;
+				}
 			}
 		}
 

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -79,14 +79,14 @@
 						<?php \esc_html_e( 'Number of images', 'activitypub' ); ?>
 					</th>
 					<td>
-						<textarea name="activitypub_number_images" id="activitypub_number_images" rows="1" cols="50" class="large-text"><?php echo esc_html( \get_option( 'activitypub_number_images', ACTIVITYPUB_NUMBER_IMAGES ) ); ?></textarea>
+						<textarea name="activitypub_max_image_attachments" id="activitypub_max_image_attachments" rows="1" cols="50" class="large-text"><?php echo esc_html( \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) ); ?></textarea>
 						<p class="description">
 							<?php
 							echo \wp_kses(
 								\sprintf(
 									// translators:
 									\__( 'The number of images to attach to posts. Default: <code>%s</code>', 'activitypub' ),
-									\esc_html( ACTIVITYPUB_NUMBER_IMAGES )
+									\esc_html( ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS )
 								),
 								'default'
 							);

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -76,6 +76,26 @@
 				</tr>
 				<tr>
 					<th scope="row">
+						<?php \esc_html_e( 'Number of images', 'activitypub' ); ?>
+					</th>
+					<td>
+						<textarea name="activitypub_number_images" id="activitypub_number_images" rows="1" cols="50" class="large-text"><?php echo esc_html( \get_option( 'activitypub_number_images', ACTIVITYPUB_NUMBER_IMAGES ) ); ?></textarea>
+						<p class="description">
+							<?php
+							echo \wp_kses(
+								\sprintf(
+									// translators:
+									\__( 'The number of images to attach to posts. Default: <code>%s</code>', 'activitypub' ),
+									\esc_html( ACTIVITYPUB_NUMBER_IMAGES )
+								),
+								'default'
+							);
+							?>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">
 						<?php \esc_html_e( 'Activity-Object-Type', 'activitypub' ); ?>
 					</th>
 					<td>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -79,7 +79,7 @@
 						<?php \esc_html_e( 'Number of images', 'activitypub' ); ?>
 					</th>
 					<td>
-						<textarea name="activitypub_max_image_attachments" id="activitypub_max_image_attachments" rows="1" cols="50" class="large-text"><?php echo esc_html( \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) ); ?></textarea>
+						<input value="<?php echo esc_attr( \get_option( 'activitypub_max_image_attachments', ACTIVITYPUB_MAX_IMAGE_ATTACHMENTS ) ); ?>" name="activitypub_max_image_attachments" id="activitypub_max_image_attachments" type="number" min="0" />
 						<p class="description">
 							<?php
 							echo \wp_kses(


### PR DESCRIPTION
Currently the plugin sends up to three images when publishing via ActivityPub.  This is probably more than Mastodon users, especially, are used to.  This is particularly true if you're only publishing an excerpt of the full article.  Alternatively, for very image-heavy posts, it might not be enough.  It should be configurable.