### PR TITLE
Give the notice boxes some margin so they have some space.

### DIFF
--- a/assets/css/activitypub-admin.css
+++ b/assets/css/activitypub-admin.css
@@ -1,6 +1,7 @@
 .settings_page_activitypub .notice {
 	max-width: 800px;
-	margin: 0 auto;
+	margin: auto;
+	margin-top: 10px;
 }
 
 .activitypub-settings-header {


### PR DESCRIPTION
Currently, if you save settings, the two notice boxes sit righ on top of each other like so:
![Screenshot from 2023-01-13 20-15-59](https://user-images.githubusercontent.com/9053749/212443880-c7a37b60-8d78-445e-9e23-0a37b920dfa4.png)

Which is a little ugly, so give them some space by adding a top margin:
![Screenshot from 2023-01-13 20-15-39](https://user-images.githubusercontent.com/9053749/212443899-f91eebe8-bcdd-4a66-8e31-5adce059b11a.png)
