### PR TITLE
Move the activitypub endpoint rule to the main rewrite addition function

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -116,6 +116,8 @@ function add_rewrite_rules() {
 		\add_rewrite_rule( '^.well-known/nodeinfo', 'index.php?rest_route=/activitypub/1.0/nodeinfo/discovery', 'top' );
 		\add_rewrite_rule( '^.well-known/x-nodeinfo2', 'index.php?rest_route=/activitypub/1.0/nodeinfo2', 'top' );
 	}
+
+	\add_rewrite_endpoint( 'activitypub', EP_AUTHORS | EP_PERMALINK | EP_PAGES );
 }
 \add_action( 'init', '\Activitypub\add_rewrite_rules', 1 );
 

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -13,7 +13,6 @@ class Activitypub {
 	public static function init() {
 		\add_filter( 'template_include', array( '\Activitypub\Activitypub', 'render_json_template' ), 99 );
 		\add_filter( 'query_vars', array( '\Activitypub\Activitypub', 'add_query_vars' ) );
-		\add_action( 'init', array( '\Activitypub\Activitypub', 'add_rewrite_endpoint' ) );
 		\add_filter( 'pre_get_avatar_data', array( '\Activitypub\Activitypub', 'pre_get_avatar_data' ), 11, 2 );
 
 		// Add support for ActivityPub to custom post types
@@ -94,13 +93,6 @@ class Activitypub {
 		$vars[] = 'activitypub';
 
 		return $vars;
-	}
-
-	/**
-	 * Add our rewrite endpoint to permalinks and pages.
-	 */
-	public static function add_rewrite_endpoint() {
-		\add_rewrite_endpoint( 'activitypub', EP_AUTHORS | EP_PERMALINK | EP_PAGES );
 	}
 
 	/**


### PR DESCRIPTION
This is for two reasons:
- No need to add the endpoint every time the plugin loads.
- The old code didn't flush the rewrite rules, making the endpoint non-functional until something did (like the user saving the permalink settings)