### PR TITLE
Hashtags: Protect HTML tags from being broken

### DIFF
--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -43,7 +43,21 @@ class Hashtag {
 	 * @return string the filtered post-content
 	 */
 	public static function the_content( $the_content ) {
+		$protected_tags = array();
+		$the_content = preg_replace_callback(
+			'#<[^>]+>#i',
+			function( $m ) use ( &$protected_tags ) {
+				$c = count( $protected_tags );
+				$protect = '!#!#PROTECT' . $c . '#!#!';
+				$protected_tags[ $protect ] = $m[0];
+				return $protect;
+			},
+			$the_content
+		);
+
 		$the_content = \preg_replace_callback( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', array( '\Activitypub\Hashtag', 'replace_with_links' ), $the_content );
+
+		$the_content = str_replace( array_keys( $protected_tags ), array_values( $protected_tags ), $the_content );
 
 		return $the_content;
 	}


### PR DESCRIPTION
If your post has HTML that contains something that resembles a hashtag, the ActivityPub plugin currently breaks that tag by replacing new HTML tags into the other tag.

Specifically, this HTML:
```
<span style="color: #ccc">Only friends</span>
```

will be transformed to this:
```
<span style="color: <a rel="tag" class="u-tag u-category" href="https://alex.kirk.at/tag/ccc/">#ccc</a>;&#8221;>Only friends</span>
```

which visually appears like this:

![Screenshot 2023-01-27 at 12 07 34](https://user-images.githubusercontent.com/203408/215073125-d6d3b591-f903-4e32-a6c6-b9ccca6b3f52.png)

This PR adds protection of the tag before the replacing operation happens and then replaces them back in, resulting in unmodified tags inside HTML:

![Screenshot 2023-01-27 at 12 09 23](https://user-images.githubusercontent.com/203408/215073870-b828ce0b-3a7f-4ca3-bdd5-2cb0a9eb137c.png)

