### PR TITLE
Fix accessing post properties

### DIFF
--- a/includes/model/class-post.php
+++ b/includes/model/class-post.php
@@ -108,6 +108,9 @@ class Post {
 		$var = \strtolower( \substr( $method, 4 ) );
 
 		if ( \strncasecmp( $method, 'get', 3 ) === 0 ) {
+			if ( empty( $this->$var ) && ! empty( $this->post->$var ) ) {
+				return $this->post->$var;
+			}
 			return $this->$var;
 		}
 


### PR DESCRIPTION
In dbaddd91890f4926ce3f8055e1c35947119dbd2f accessing the properties of the inner WP_Post was broken. I discovered this while rebasing #213 which has tests for this.