### PR TITLE
Protect HTML between certain tags

### DIFF
--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -45,7 +45,7 @@ class Hashtag {
 	public static function the_content( $the_content ) {
 		$protected_tags = array();
 		$the_content = preg_replace_callback(
-			'#<(code|textarea|style)\b[^>]*>.*?</\1[^>]*>#i',
+			'#<(pre|code|textarea|style)\b[^>]*>.*?</\1[^>]*>#is',
 			function( $m ) use ( &$protected_tags ) {
 				$c = count( $protected_tags );
 				$protect = '!#!#PROTECT' . $c . '#!#!';

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -51,7 +51,7 @@ class Hashtag {
 			return $protect;
 		};
 		$the_content = preg_replace_callback(
-			'#<![CDATA[.*?]]>#is',
+			'#<!\[CDATA\[.*?\]\]>#is',
 			$protect,
 			$the_content
 		);
@@ -68,7 +68,7 @@ class Hashtag {
 
 		$the_content = \preg_replace_callback( '/' . ACTIVITYPUB_HASHTAGS_REGEXP . '/i', array( '\Activitypub\Hashtag', 'replace_with_links' ), $the_content );
 
-		$the_content = str_replace( array_keys( $protected_tags ), array_values( $protected_tags ), $the_content );
+		$the_content = str_replace( array_reverse( array_keys( $protected_tags ) ), array_reverse( array_values( $protected_tags ) ), $the_content );
 
 		return $the_content;
 	}

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -20,7 +20,7 @@ class Hashtag {
 	/**
 	 * Filter to save #tags as real WordPress tags
 	 *
-	 * @param int $id the rev-id
+	 * @param int     $id the rev-id
 	 * @param WP_Post $post the post
 	 *
 	 * @return
@@ -44,6 +44,16 @@ class Hashtag {
 	 */
 	public static function the_content( $the_content ) {
 		$protected_tags = array();
+		$the_content = preg_replace_callback(
+			'#<(code|textarea|style)\b[^>]*>.*?</\1[^>]*>#i',
+			function( $m ) use ( &$protected_tags ) {
+				$c = count( $protected_tags );
+				$protect = '!#!#PROTECT' . $c . '#!#!';
+				$protected_tags[ $protect ] = $m[0];
+				return $protect;
+			},
+			$the_content
+		);
 		$the_content = preg_replace_callback(
 			'#<[^>]+>#i',
 			function( $m ) use ( &$protected_tags ) {

--- a/includes/class-hashtag.php
+++ b/includes/class-hashtag.php
@@ -44,24 +44,25 @@ class Hashtag {
 	 */
 	public static function the_content( $the_content ) {
 		$protected_tags = array();
+		$protect = function( $m ) use ( &$protected_tags ) {
+			$c = count( $protected_tags );
+			$protect = '!#!#PROTECT' . $c . '#!#!';
+			$protected_tags[ $protect ] = $m[0];
+			return $protect;
+		};
+		$the_content = preg_replace_callback(
+			'#<![CDATA[.*?]]>#is',
+			$protect,
+			$the_content
+		);
 		$the_content = preg_replace_callback(
 			'#<(pre|code|textarea|style)\b[^>]*>.*?</\1[^>]*>#is',
-			function( $m ) use ( &$protected_tags ) {
-				$c = count( $protected_tags );
-				$protect = '!#!#PROTECT' . $c . '#!#!';
-				$protected_tags[ $protect ] = $m[0];
-				return $protect;
-			},
+			$protect,
 			$the_content
 		);
 		$the_content = preg_replace_callback(
 			'#<[^>]+>#i',
-			function( $m ) use ( &$protected_tags ) {
-				$c = count( $protected_tags );
-				$protect = '!#!#PROTECT' . $c . '#!#!';
-				$protected_tags[ $protect ] = $m[0];
-				return $protect;
-			},
+			$protect,
 			$the_content
 		);
 

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -25,6 +25,16 @@ class Mention {
 	public static function the_content( $the_content ) {
 		$protected_tags = array();
 		$the_content = preg_replace_callback(
+			'#<(code|textarea|style)\b[^>]*>.*?</\1[^>]*>#i',
+			function( $m ) use ( &$protected_tags ) {
+				$c = count( $protected_tags );
+				$protect = '!#!#PROTECT' . $c . '#!#!';
+				$protected_tags[ $protect ] = $m[0];
+				return $protect;
+			},
+			$the_content
+		);
+		$the_content = preg_replace_callback(
 			'#<a.*?href=[^>]+>.*?</a>#i',
 			function( $m ) use ( &$protected_tags ) {
 				$c = count( $protected_tags );
@@ -68,7 +78,7 @@ class Mention {
 	/**
 	 * Extract the mentions from the post_content.
 	 *
-	 * @param array $mentions The already found mentions.
+	 * @param array  $mentions The already found mentions.
 	 * @param string $post_content The post content.
 	 * @return mixed The discovered mentions.
 	 */

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -25,7 +25,7 @@ class Mention {
 	public static function the_content( $the_content ) {
 		$protected_tags = array();
 		$the_content = preg_replace_callback(
-			'#<(code|textarea|style)\b[^>]*>.*?</\1[^>]*>#i',
+			'#<(pre|code|textarea|style)\b[^>]*>.*?</\1[^>]*>#is',
 			function( $m ) use ( &$protected_tags ) {
 				$c = count( $protected_tags );
 				$protect = '!#!#PROTECT' . $c . '#!#!';

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -24,24 +24,25 @@ class Mention {
 	 */
 	public static function the_content( $the_content ) {
 		$protected_tags = array();
+		$protect = function( $m ) use ( &$protected_tags ) {
+			$c = count( $protected_tags );
+			$protect = '!#!#PROTECT' . $c . '#!#!';
+			$protected_tags[ $protect ] = $m[0];
+			return $protect;
+		};
+		$the_content = preg_replace_callback(
+			'#<![CDATA[.*?]]>#is',
+			$protect,
+			$the_content
+		);
 		$the_content = preg_replace_callback(
 			'#<(pre|code|textarea|style)\b[^>]*>.*?</\1[^>]*>#is',
-			function( $m ) use ( &$protected_tags ) {
-				$c = count( $protected_tags );
-				$protect = '!#!#PROTECT' . $c . '#!#!';
-				$protected_tags[ $protect ] = $m[0];
-				return $protect;
-			},
+			$protect,
 			$the_content
 		);
 		$the_content = preg_replace_callback(
 			'#<a.*?href=[^>]+>.*?</a>#i',
-			function( $m ) use ( &$protected_tags ) {
-				$c = count( $protected_tags );
-				$protect = '!#!#PROTECT' . $c . '#!#!';
-				$protected_tags[ $protect ] = $m[0];
-				return $protect;
-			},
+			$protect,
 			$the_content
 		);
 

--- a/includes/class-mention.php
+++ b/includes/class-mention.php
@@ -31,7 +31,7 @@ class Mention {
 			return $protect;
 		};
 		$the_content = preg_replace_callback(
-			'#<![CDATA[.*?]]>#is',
+			'#<!\[CDATA\[.*?\]\]>#is',
 			$protect,
 			$the_content
 		);
@@ -48,7 +48,7 @@ class Mention {
 
 		$the_content = \preg_replace_callback( '/@' . ACTIVITYPUB_USERNAME_REGEXP . '/', array( '\Activitypub\Mention', 'replace_with_links' ), $the_content );
 
-		$the_content = str_replace( array_keys( $protected_tags ), array_values( $protected_tags ), $the_content );
+		$the_content = str_replace( array_reverse( array_keys( $protected_tags ) ), array_reverse( array_values( $protected_tags ) ), $the_content );
 
 		return $the_content;
 	}

--- a/tests/test-class-activitypub-hashtag.php
+++ b/tests/test-class-activitypub-hashtag.php
@@ -5,6 +5,7 @@ class Test_Activitypub_Hashtag extends WP_UnitTestCase {
 	 */
 	public function test_the_content( $content, $content_with_hashtag ) {
 		\wp_create_term( 'object', 'post_tag' );
+		\wp_create_term( 'ccc', 'post_tag' );
 		$object = \get_term_by( 'name', 'object', 'post_tag' );
 		$link = \get_term_link( $object, 'post_tag' );
 
@@ -14,6 +15,15 @@ class Test_Activitypub_Hashtag extends WP_UnitTestCase {
 	}
 
 	public function the_content_provider() {
+		$code = '<code>text with some #object and <a> tag inside</code>';
+		$style = <<<ENDSTYLE
+<style type="text/css">
+<![[
+color: #ccc;
+]]>
+</style>
+ENDSTYLE;
+		$textarea = '<textarea name="test" rows="20">color: #ccc</textarea>';
 		return array(
 			array( 'test', 'test' ),
 			array( '#test', '#test' ),
@@ -27,6 +37,9 @@ class Test_Activitypub_Hashtag extends WP_UnitTestCase {
 			array( '<div>#object</div>', '<div>#object</div>' ),
 			array( '<a>#object</a>', '<a>#object</a>' ),
 			array( '<div style="color: #ccc;">object</a>', '<div style="color: #ccc;">object</a>' ),
+			array( $code, $code ),
+			array( $style, $style ),
+			array( $textarea, $textarea ),
 		);
 	}
 }

--- a/tests/test-class-activitypub-hashtag.php
+++ b/tests/test-class-activitypub-hashtag.php
@@ -19,7 +19,7 @@ class Test_Activitypub_Hashtag extends WP_UnitTestCase {
 		$code = '<code>text with some #object and <a> tag inside</code>';
 		$style = <<<ENDSTYLE
 <style type="text/css">
-<![[
+<![CDATA[
 color: #ccc;
 ]]>
 </style>

--- a/tests/test-class-activitypub-hashtag.php
+++ b/tests/test-class-activitypub-hashtag.php
@@ -5,6 +5,7 @@ class Test_Activitypub_Hashtag extends WP_UnitTestCase {
 	 */
 	public function test_the_content( $content, $content_with_hashtag ) {
 		\wp_create_term( 'object', 'post_tag' );
+		\wp_create_term( 'touch', 'post_tag' );
 		\wp_create_term( 'ccc', 'post_tag' );
 		$object = \get_term_by( 'name', 'object', 'post_tag' );
 		$link = \get_term_link( $object, 'post_tag' );
@@ -23,6 +24,12 @@ color: #ccc;
 ]]>
 </style>
 ENDSTYLE;
+		$pre = <<<ENDPRE
+<pre>
+Please don't #touch
+  this.
+</pre>
+ENDPRE;
 		$textarea = '<textarea name="test" rows="20">color: #ccc</textarea>';
 		return array(
 			array( 'test', 'test' ),
@@ -40,6 +47,7 @@ ENDSTYLE;
 			array( $code, $code ),
 			array( $style, $style ),
 			array( $textarea, $textarea ),
+			array( $pre, $pre ),
 		);
 	}
 }

--- a/tests/test-class-activitypub-mention.php
+++ b/tests/test-class-activitypub-mention.php
@@ -2,8 +2,8 @@
 class Test_Activitypub_Mention extends ActivityPub_TestCase_Cache_HTTP {
 	public static $users = array(
 		'username@example.org' => array(
-			'url' => 'https://example.org/users/username',
-			'name'  => 'username',
+			'url'  => 'https://example.org/users/username',
+			'name' => 'username',
 		),
 	);
 	/**
@@ -18,12 +18,14 @@ class Test_Activitypub_Mention extends ActivityPub_TestCase_Cache_HTTP {
 	}
 
 	public function the_content_provider() {
+		$code = 'hallo <code>@username@example.org</code> test';
 		return array(
 			array( 'hallo @username@example.org test', 'hallo <a rel="mention" class="u-url mention" href="https://example.org/users/username">@<span>username</span></a> test' ),
 			array( 'hallo @pfefferle@notiz.blog test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@<span>pfefferle</span></a> test' ),
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@<span>pfefferle</span>@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@<span>pfefferle</span>@notiz.blog</a> test' ),
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@pfefferle@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@pfefferle@notiz.blog</a> test' ),
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/@pfefferle/">@pfefferle@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/@pfefferle/">@pfefferle@notiz.blog</a> test' ),
+			array( $code, $code ),
 		);
 	}
 

--- a/tests/test-class-activitypub-mention.php
+++ b/tests/test-class-activitypub-mention.php
@@ -19,6 +19,12 @@ class Test_Activitypub_Mention extends ActivityPub_TestCase_Cache_HTTP {
 
 	public function the_content_provider() {
 		$code = 'hallo <code>@username@example.org</code> test';
+		$pre = <<<ENDPRE
+<pre>
+Please don't mention @username@example.org
+  here.
+</pre>
+ENDPRE;
 		return array(
 			array( 'hallo @username@example.org test', 'hallo <a rel="mention" class="u-url mention" href="https://example.org/users/username">@<span>username</span></a> test' ),
 			array( 'hallo @pfefferle@notiz.blog test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@<span>pfefferle</span></a> test' ),
@@ -26,6 +32,7 @@ class Test_Activitypub_Mention extends ActivityPub_TestCase_Cache_HTTP {
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@pfefferle@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/author/matthias-pfefferle/">@pfefferle@notiz.blog</a> test' ),
 			array( 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/@pfefferle/">@pfefferle@notiz.blog</a> test', 'hallo <a rel="mention" class="u-url mention" href="https://notiz.blog/@pfefferle/">@pfefferle@notiz.blog</a> test' ),
 			array( $code, $code ),
+			array( $pre, $pre ),
 		);
 	}
 


### PR DESCRIPTION
We also need to prevent the code between HTML elements in some cases, for example inside `<code>` or `<pre>`. This adds some more unit tests as well.

```
<pre>
Please don't mention @username@example.org
  here.
</pre>
```

should not become
```
<pre>
Please don't mention <a rel="mention" class="u-url mention" href="https://example.org/users/username">@<span>username</span></a>
   here.
 </pre>
```

See https://wordpress.org/support/topic/block-shows-raw-html-on-frontend/