### PR TITLE
Add ActivityPub specific user description

### DIFF
--- a/activitypub.php
+++ b/activitypub.php
@@ -25,6 +25,7 @@ function init() {
 	\defined( 'ACTIVITYPUB_USERNAME_REGEXP' ) || \define( 'ACTIVITYPUB_USERNAME_REGEXP', '(?:([A-Za-z0-9_-]+)@((?:[A-Za-z0-9_-]+\.)+[A-Za-z]+))' );
 	\defined( 'ACTIVITYPUB_ALLOWED_HTML' ) || \define( 'ACTIVITYPUB_ALLOWED_HTML', '<strong><a><p><ul><ol><li><code><blockquote><pre><img>' );
 	\defined( 'ACTIVITYPUB_CUSTOM_POST_CONTENT' ) || \define( 'ACTIVITYPUB_CUSTOM_POST_CONTENT', "<p><strong>[ap_title]</strong></p>\n\n[ap_content]\n\n<p>[ap_hashtags]</p>\n\n<p>[ap_shortlink]</p>" );
+	\defined( 'ACTIVITYPUB_USER_DESCRIPTION_KEY' ) || \define( 'ACTIVITYPUB_USER_DESCRIPTION_KEY', 'activitypub_user_description' );
 	\define( 'ACTIVITYPUB_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 	\define( 'ACTIVITYPUB_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 	\define( 'ACTIVITYPUB_PLUGIN_FILE', plugin_dir_path( __FILE__ ) . '/' . basename( __FILE__ ) );

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -162,9 +162,9 @@ class Admin {
 		?>
 		<table class="form-table" role="presentation">
 			<tr class="activitypub-user-description-wrap">
-				<th><label for="activitypub-user-description"><?php _e( 'Fediverse Biography', 'activitypub' ); ?></label></th>
-				<td><textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30"><?php echo \esc_html( $ap_description ) ?></textarea>
-				<p><?php _e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p></td>
+				<th><label for="activitypub-user-description"><?php \esc_html_e( 'Fediverse Biography', 'activitypub' ); ?></label></th>
+				<td><textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30"><?php echo \esc_html( $ap_description ); ?></textarea>
+				<p><?php \esc_html_e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p></td>
 			</tr>
 		</table>
 		<?php

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -14,7 +14,7 @@ class Admin {
 		\add_action( 'admin_menu', array( self::class, 'admin_menu' ) );
 		\add_action( 'admin_init', array( self::class, 'register_settings' ) );
 		\add_action( 'show_user_profile', array( self::class, 'add_fediverse_profile' ) );
-    \add_action( 'personal_options_update', array( self::class, 'save_user_description' ) );
+		\add_action( 'personal_options_update', array( self::class, 'save_user_description' ) );
 		\add_action( 'admin_enqueue_scripts', array( self::class, 'enqueue_scripts' ) );
 	}
 

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -14,6 +14,7 @@ class Admin {
 		\add_action( 'admin_menu', array( '\Activitypub\Admin', 'admin_menu' ) );
 		\add_action( 'admin_init', array( '\Activitypub\Admin', 'register_settings' ) );
 		\add_action( 'show_user_profile', array( '\Activitypub\Admin', 'add_fediverse_profile' ) );
+		\add_action( 'personal_options_update', array( '\Activitypub\Admin', 'save_user_description' ) );
 		\add_action( 'admin_enqueue_scripts', array( '\Activitypub\Admin', 'enqueue_scripts' ) );
 	}
 
@@ -153,10 +154,27 @@ class Admin {
 	}
 
 	public static function add_fediverse_profile( $user ) {
+		$ap_description = get_user_meta( $user->ID, ACTIVITYPUB_USER_DESCRIPTION_KEY, true );
 		?>
 		<h2 id="activitypub"><?php \esc_html_e( 'ActivityPub', 'activitypub' ); ?></h2>
 		<?php
 		\Activitypub\get_identifier_settings( $user->ID );
+		?>
+		<table class="form-table" role="presentation">
+			<tr class="activitypub-user-description-wrap">
+				<th><label for="activitypub-user-description"><?php _e( 'Fediverse Biography', 'activitypub' ); ?></label></th>
+				<td><textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30"><?php echo \esc_html( $ap_description ) ?></textarea>
+				<p><?php _e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p></td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	public static function save_user_description( $user_id ) {
+		if ( ! current_user_can( 'edit_user', $user_id ) ) {
+			return false;
+		}
+		update_user_meta( $user_id, ACTIVITYPUB_USER_DESCRIPTION_KEY, sanitize_text_field( $_POST['activitypub-user-description'] ) );
 	}
 
 	public static function enqueue_scripts( $hook_suffix ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -1,6 +1,8 @@
 <?php
 namespace Activitypub;
 
+use Activitypub\Model\Post;
+
 /**
  * ActivityPub Admin Class
  *
@@ -51,9 +53,9 @@ class Admin {
 
 		switch ( $tab ) {
 			case 'settings':
-				\Activitypub\Model\Post::upgrade_post_content_template();
+				Post::upgrade_post_content_template();
 
-				\load_template( \dirname( __FILE__ ) . '/../templates/settings.php' );
+				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/settings.php' );
 				break;
 			case 'welcome':
 			default:
@@ -61,7 +63,7 @@ class Admin {
 				add_thickbox();
 				wp_enqueue_script( 'updates' );
 
-				\load_template( \dirname( __FILE__ ) . '/../templates/welcome.php' );
+				\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/welcome.php' );
 				break;
 		}
 	}
@@ -70,7 +72,7 @@ class Admin {
 	 * Load user settings page
 	 */
 	public static function followers_list_page() {
-		\load_template( \dirname( __FILE__ ) . '/../templates/followers-list.php' );
+		\load_template( ACTIVITYPUB_PLUGIN_DIR . 'templates/followers-list.php' );
 	}
 
 	/**
@@ -146,7 +148,7 @@ class Admin {
 	}
 
 	public static function add_settings_help_tab() {
-		require_once \dirname( __FILE__ ) . '/help.php';
+		require_once ACTIVITYPUB_PLUGIN_DIR . 'includes/help.php';
 	}
 
 	public static function add_followers_list_help_tab() {
@@ -154,25 +156,19 @@ class Admin {
 	}
 
 	public static function add_fediverse_profile( $user ) {
-		$ap_description = get_user_meta( $user->ID, ACTIVITYPUB_USER_DESCRIPTION_KEY, true );
-		?>
-		<h2 id="activitypub"><?php \esc_html_e( 'ActivityPub', 'activitypub' ); ?></h2>
-		<?php
-		\Activitypub\get_identifier_settings( $user->ID );
-		?>
-		<table class="form-table" role="presentation">
-			<tr class="activitypub-user-description-wrap">
-				<th><label for="activitypub-user-description"><?php \esc_html_e( 'Fediverse Biography', 'activitypub' ); ?></label></th>
-				<td><textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30"><?php echo \esc_html( $ap_description ); ?></textarea>
-				<p><?php \esc_html_e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p></td>
-				<?php wp_nonce_field( 'activitypub-user-description', '_apnonce' ); ?>
-			</tr>
-		</table>
-		<?php
+		$description = get_user_meta( $user->ID, ACTIVITYPUB_USER_DESCRIPTION_KEY, true );
+
+		\load_template(
+			ACTIVITYPUB_PLUGIN_DIR . 'templates/user-settings.php',
+			true,
+			array(
+				'description' => $description,
+			)
+		);
 	}
 
 	public static function save_user_description( $user_id ) {
-		if ( ! wp_verify_nonce( $_REQUEST['_apnonce'], 'activitypub-user-description' ) ) {
+		if ( isset( $_REQUEST['_apnonce'] ) && ! wp_verify_nonce( $_REQUEST['_apnonce'], 'activitypub-user-description' ) ) {
 			return false;
 		}
 		if ( ! current_user_can( 'edit_user', $user_id ) ) {

--- a/includes/class-admin.php
+++ b/includes/class-admin.php
@@ -165,12 +165,16 @@ class Admin {
 				<th><label for="activitypub-user-description"><?php \esc_html_e( 'Fediverse Biography', 'activitypub' ); ?></label></th>
 				<td><textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30"><?php echo \esc_html( $ap_description ); ?></textarea>
 				<p><?php \esc_html_e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p></td>
+				<?php wp_nonce_field( 'activitypub-user-description', '_apnonce' ); ?>
 			</tr>
 		</table>
 		<?php
 	}
 
 	public static function save_user_description( $user_id ) {
+		if ( ! wp_verify_nonce( $_REQUEST['_apnonce'], 'activitypub-user-description' ) ) {
+			return false;
+		}
 		if ( ! current_user_can( 'edit_user', $user_id ) ) {
 			return false;
 		}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -320,3 +320,17 @@ function url_to_authorid( $url ) {
 
 	return 0;
 }
+
+/**
+ * Return the custom Activity Pub description, if set, or default author description.
+ *
+ * @param int $user_id The user ID.
+ * @return string
+ */
+function get_author_description( $user_id ) {
+	$description = get_user_meta( $user_id, ACTIVITYPUB_USER_DESCRIPTION_KEY, true );
+	if ( empty( $description ) ) {
+		$description = get_user_meta( $user_id, 'description', true );
+	}
+	return $description;
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -241,25 +241,6 @@ function get_follower_inboxes( $user_id, $cc = array() ) {
 	return $inboxes;
 }
 
-function get_identifier_settings( $user_id ) {
-	?>
-<table class="form-table">
-	<tbody>
-		<tr>
-			<th scope="row">
-				<label><?php \esc_html_e( 'Profile identifier', 'activitypub' ); ?></label>
-			</th>
-			<td>
-				<p><code><?php echo \esc_html( \Activitypub\get_webfinger_resource( $user_id ) ); ?></code> or <code><?php echo \esc_url( \get_author_posts_url( $user_id ) ); ?></code></p>
-				<?php // translators: the webfinger resource ?>
-				<p class="description"><?php \printf( \esc_html__( 'Try to follow "@%s" by searching for it on Mastodon,Friendica & Co.', 'activitypub' ), \esc_html( \Activitypub\get_webfinger_resource( $user_id ) ) ); ?></p>
-			</td>
-		</tr>
-	</tbody>
-</table>
-	<?php
-}
-
 function get_followers( $user_id ) {
 	$followers = \Activitypub\Peer\Followers::get_followers( $user_id );
 

--- a/templates/author-json.php
+++ b/templates/author-json.php
@@ -8,7 +8,7 @@ $json->id = \get_author_posts_url( $author_id );
 $json->type = 'Person';
 $json->name = \get_the_author_meta( 'display_name', $author_id );
 $json->summary = \html_entity_decode(
-	\get_the_author_meta( 'description', $author_id ),
+	\Activitypub\get_author_description( $author_id ),
 	\ENT_QUOTES,
 	'UTF-8'
 );

--- a/templates/user-settings.php
+++ b/templates/user-settings.php
@@ -1,0 +1,29 @@
+<h2 id="activitypub"><?php \esc_html_e( 'ActivityPub', 'activitypub' ); ?></h2>
+
+<table class="form-table">
+	<tbody>
+		<tr>
+			<th scope="row">
+				<label><?php \esc_html_e( 'Profile identifier', 'activitypub' ); ?></label>
+			</th>
+			<td>
+				<p>
+					<code><?php echo \esc_html( \Activitypub\get_webfinger_resource( \get_current_user_id() ) ); ?></code> or
+					<code><?php echo \esc_url( \get_author_posts_url( \get_current_user_id() ) ); ?></code>
+				</p>
+				<?php // translators: the webfinger resource ?>
+				<p class="description"><?php \printf( \esc_html__( 'Try to follow "@%s" by searching for it on Mastodon,Friendica & Co.', 'activitypub' ), \esc_html( \Activitypub\get_webfinger_resource( \get_current_user_id() ) ) ); ?></p>
+			</td>
+		</tr>
+		<tr class="activitypub-user-description-wrap">
+			<th>
+				<label for="activitypub-user-description"><?php \esc_html_e( 'Biography', 'activitypub' ); ?></label>
+			</th>
+			<td>
+				<textarea name="activitypub-user-description" id="activitypub-user-description" rows="5" cols="30" placeholder="<?php echo \esc_html( get_user_meta( \get_current_user_id(), 'description', true ) ); ?>"><?php echo \esc_html( $args['description'] ); ?></textarea>
+				<p class="description"><?php \esc_html_e( 'If you wish to use different biographical info for the fediverse, enter your alternate bio here.', 'activitypub' ); ?></p>
+			</td>
+			<?php wp_nonce_field( 'activitypub-user-description', '_apnonce' ); ?>
+		</tr>
+	</tbody>
+</table>


### PR DESCRIPTION
Address issue #165, a feature request for a user bio specific to the fediverse, separate from the WP standard user description field.

The PR provides the following

- A const for the user meta key for storing/retrieving the AP bio
- Profile fields and save handling for the AP bio on the user edit screen; as implemented here the form field only displays when a user is editing their own profile; if the ability to see and/or edit another user's AP bio is desired, e.g. an Administrator editing a Contributor's AP bio, I can add that to this PR; it's two additional action hooks and some extra capability checks at most
- Template helper to display the AP specific bio first, if set, or defer to the default; an empty string is returned if both are unset
- Updates the author-json.php template to use the new template function to display the correct description in the summary field.
<img width="894" alt="ap-user-desc" src="https://user-images.githubusercontent.com/73679/225106303-4fb03506-caca-425d-b696-f9d4e5ef57fd.png">

Verification:

- edit and save the Fediverse Biography field on a user edit screen to confirm form data handling is correct
- using the dev console or command line, request an author profile (e.g. http://activitypub.local/author/admin) with an `Accept: application/activity+json` header to verify the `summary` field in the returned JSON has the correct value: fediverse bio if set, standard author description if no fediverse bio, empty string if neither is set