### PR TITLE
Webfinger info: avoid PHP warning when user isn't defined

### DIFF
--- a/includes/class-webfinger.php
+++ b/includes/class-webfinger.php
@@ -23,6 +23,9 @@ class Webfinger {
 		}
 
 		$user = \get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return '';
+		}
 
 		return $user->user_login . '@' . \wp_parse_url( \home_url(), \PHP_URL_HOST );
 	}


### PR DESCRIPTION
This should avoid warnings like this one:

```
PHP Warning:  Attempt to read property "user_login" on bool in /var/www/html/wp-content/plugins/activitypub/includes/class-webfinger.php on line 27
```