### PR TITLE
Fix Edge Caching Problems

### DIFF
--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -39,6 +39,8 @@ class Activitypub {
 			return $template;
 		}
 
+		header( 'Vary: Accept' );
+
 		// check if user can publish posts
 		if ( \is_author() && ! user_can( \get_the_author_meta( 'ID' ), 'publish_posts' ) ) {
 			return $template;

--- a/includes/class-activitypub.php
+++ b/includes/class-activitypub.php
@@ -39,6 +39,7 @@ class Activitypub {
 			return $template;
 		}
 
+		// Ensure that edge caches know that this page can deliver both HTML and JSON.
 		header( 'Vary: Accept' );
 
 		// check if user can publish posts


### PR DESCRIPTION
I saw that many people have problems (including with WordPress caching plugins) but also with Cloudflare, that JSON is being delivered instead of HTML. This is because we're not announcing that multiple versions exist depending on an incoming `Accept:` header. This can be fixed through a `Vary` HTTP header, see https://www.fastly.com/blog/best-practices-using-vary-header